### PR TITLE
Add translations to the search suggestion dropdown

### DIFF
--- a/translations/de/makaira_lang.php
+++ b/translations/de/makaira_lang.php
@@ -16,6 +16,10 @@ $aLang = [
     'MAKAIRA_SEARCHRESULT_SUGGESTION'   => "Suchvorschläge",
     'MAKAIRA_PRODUCTS'                  => "Produkte",
 
+    // SUGGESTIONS
+    'MAKAIRA_SUGGESTION_SEARCHLINK'     => "Links",
+    'MAKAIRA_SUGGESTION_SHOW_ALL'       => "Alle Ergebnisse anzeigen",
+
     // Cookie consent hint
     'MAKAIRA_COOKIE_BANNER_HEADING'     => 'Cookie-Einstellungen',
     'MAKAIRA_COOKIE_BANNER_INFO'        => 'Unsere Webseite setzt Cookies ein, um unsere Dienste für Sie bereitzustellen. Ebenfalls werden Cookies ' .

--- a/translations/en/makaira_lang.php
+++ b/translations/en/makaira_lang.php
@@ -16,6 +16,10 @@ $aLang = [
     'MAKAIRA_SEARCHRESULT_SUGGESTION'   => "Suggestions",
     'MAKAIRA_PRODUCTS'                  => "Products",
 
+    // SUGGESTIONS
+    'MAKAIRA_SUGGESTION_SEARCHLINK'     => "Links",
+    'MAKAIRA_SUGGESTION_SHOW_ALL'       => "Show all results",
+
     // Cookie Consent
     'MAKAIRA_COOKIE_BANNER_HEADING'     => 'Cookie settings',
     'MAKAIRA_COOKIE_BANNER_INFO'        => 'Our website uses cookies to provide our services to you. ' .

--- a/views/tpl/autosuggest/types/categories.tpl
+++ b/views/tpl/autosuggest/types/categories.tpl
@@ -1,4 +1,4 @@
-<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">Kategorien</li>
+<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">[{oxmultilang ident="MAKAIRA_SEARCHRESULT_CATEGORY"}]</li>
 
 [{foreach from=$categories item=category}]
     <li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--category">

--- a/views/tpl/autosuggest/types/links.tpl
+++ b/views/tpl/autosuggest/types/links.tpl
@@ -1,4 +1,4 @@
-<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">Links</li>
+<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">[{oxmultilang ident="MAKAIRA_SUGGESTION_SEARCHLINK"}]</li>
 
 [{foreach from=$links item=link}]
     <li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--link">

--- a/views/tpl/autosuggest/types/manufacturers.tpl
+++ b/views/tpl/autosuggest/types/manufacturers.tpl
@@ -1,4 +1,4 @@
-<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">Hersteller</li>
+<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">[{oxmultilang ident="MAKAIRA_SEARCHRESULT_MANUFACTURER"}]</li>
 
 [{foreach from=$manufacturers item=manufacturer}]
     <li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--manufacturer">

--- a/views/tpl/autosuggest/types/products.tpl
+++ b/views/tpl/autosuggest/types/products.tpl
@@ -1,4 +1,4 @@
-<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">Produkte</li>
+<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">[{oxmultilang ident="MAKAIRA_PRODUCTS"}]</li>
 
 [{foreach from=$products item=product}]
     <li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--product">
@@ -13,6 +13,6 @@
 
 <li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--show-all">
     <button class="makaira-autosuggestion__submit" type="submit">
-        Alle Ergebnisse anzeigen ([{$productCount}])
+        [{oxmultilang ident="MAKAIRA_SUGGESTION_SHOW_ALL"}] ([{$productCount}])
     </button>
 </li>

--- a/views/tpl/autosuggest/types/suggestions.tpl
+++ b/views/tpl/autosuggest/types/suggestions.tpl
@@ -1,4 +1,4 @@
-<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">Suchvorschläge</li>
+<li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--header">[{oxmultilang ident="MAKAIRA_SEARCHRESULT_SUGGESTION"}]</li>
 
 [{foreach from=$suggestions item=suggestion}]
     <li class="makaira-autosuggestion__list-item makaira-autosuggestion__list-item--suggestion">


### PR DESCRIPTION
This enables multilang for the headers of the suggest dropdown, those were only in German in all languages so far.
Adds translation into English.