### PR TITLE
add map Ids Hook

### DIFF
--- a/src/oxid/core/makaira_connect_request_handler.php
+++ b/src/oxid/core/makaira_connect_request_handler.php
@@ -179,10 +179,8 @@ class makaira_connect_request_handler
 
         $productResult = $this->result['product'];
 
-        $productIds = [];
-        foreach ($productResult->items as $item) {
-            $productIds[] = $item->fields['id'];
-        }
+        // hook to map ids
+        $productIds = $this->mapResultIDs($productResult->items);
 
         // Hook for result modification
         $this->afterSearchRequest($productIds);
@@ -411,5 +409,18 @@ class makaira_connect_request_handler
         }
 
         return $aggregations;
+    }
+
+    /**
+     * @param $items
+     * @return array
+     */
+    public function mapResultIDs($items)
+    {
+        $productIds = [];
+        foreach ($items as $item) {
+            $productIds[] = $item->fields['id'];
+        }
+        return $productIds;
     }
 }


### PR DESCRIPTION
Adds Map Ids Hook to Request Handler Class.

Allows to Filter/Remap Result IDs from Makaira before final Request handling.

Needed to Redirect to Variant instead of Parent. 