### PR TITLE
Import parent products as pseudo variants if parent buyable flag is set globally

### DIFF
--- a/src/Makaira/Connect/Repository.php
+++ b/src/Makaira/Connect/Repository.php
@@ -6,6 +6,7 @@ use Makaira\Import\Changes;
 use Makaira\Connect\Exception as ConnectException;
 use Makaira\Connect\Exceptions\OutOfBoundsException;
 use Makaira\Connect\Repository\AbstractRepository;
+use OxidEsales\Eshop\Core\Registry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -217,8 +218,9 @@ class Repository
 
                 if ($typeProduct === $type) {
                     if (true === $change->deleted ||
-                        (isset($change->data->OXVARCOUNT) && 0 === $change->data->OXVARCOUNT)) {
-                        $pChange                  = clone $change;
+                        (isset($change->data->OXVARCOUNT) && 0 === $change->data->OXVARCOUNT) ||
+                        Registry::getConfig()->getConfigParam('blVariantParentBuyable') === true) {
+                        $pChange = clone $change;
 
                         if (is_null($pChange->data)) {
                             $pChange->data = new \stdClass();


### PR DESCRIPTION
In OXID parents can be globally configured as buyable products.

This CR checks for the blVariantParentBuyable setting in OXID and always imports the parent product as a pseudo variant if this flag is set.