### PR TITLE
Check that variant is active when it is exportet as an attribute

### DIFF
--- a/src/Makaira/Connect/Modifier/Common/AttributeModifier.php
+++ b/src/Makaira/Connect/Modifier/Common/AttributeModifier.php
@@ -36,9 +36,8 @@ class AttributeModifier extends Modifier
                             variant.oxvarselect as `value`
                         FROM
                             oxarticles parent
-                            JOIN oxarticles variant ON parent.oxid = variant.oxparentid
-                        WHERE
-                            variant.oxparentid = :productId
+                            JOIN (SELECT * from oxarticles WHERE
+                            oxparentid = :productId AND {{activeSnippet}}) variant ON parent.oxid = variant.oxparentid
                         ';
 
     public $selectVariantsNameQuery = '
@@ -204,8 +203,10 @@ class AttributeModifier extends Modifier
                 ],
                 false
             );
+            $variantsQuery                   =
+                str_replace('{{activeSnippet}}', $this->activeSnippet, $this->selectVariantsQuery);
             $variants = $this->database->query(
-                $this->selectVariantsQuery,
+                $variantsQuery,
                 [
                     'productId' => $product->id,
                 ]


### PR DESCRIPTION
Add the active snippet to the query that gets the variants when they are written into varselect attributes. This is a bit more difficult because of the join, possibly there is a more performant solution than this.
Otherwise inactive variants will be added to the parent as `oxvarname` (Varselect) attributes.