### PR TITLE
Do not add shop-id option for OXID 6.2 EE

### DIFF
--- a/src/Makaira/Connect/Command/TouchAllCommand.php
+++ b/src/Makaira/Connect/Command/TouchAllCommand.php
@@ -11,6 +11,7 @@
 
 namespace Makaira\Connect\Command;
 
+use OxidEsales\Facts\Facts;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,14 +19,33 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Makaira\Connect\Repository;
 use Makaira\Connect\Connect;
 
+use function class_exists;
+
 class TouchAllCommand extends Command
 {
     protected function configure()
     {
         $this->setName('makaira:touch-all')
             ->setDescription('Touch all')
-            ->addOption('shop-id', null, InputOption::VALUE_REQUIRED, 'Touch objects only for the given shop.')
             ->setHelp('Trigger update of everything');
+
+        $isEnterpriseEdition = false;
+
+        // Do not add the '--shop-id' option for OXID EE 6.2, because OXID add it without any existence checks.
+        $hasCompatibilityModule = class_exists('\\Makaira\\ConnectCompat\\ContainerCompat');
+        if (!$hasCompatibilityModule) {
+            $facts               = new Facts();
+            $isEnterpriseEdition = $facts->isEnterprise();
+        }
+
+        if ($hasCompatibilityModule || !$isEnterpriseEdition) {
+            $this->addOption(
+                'shop-id',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Touch objects only for the given shop.'
+            );
+        }
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
OXID 6.2 Enterprise adds the option `--shop-id` to all console commands without checking if they already exist. This resulted in an error with our connect module.

The option is only added if
1. the compatibility module is installed, because it's only required for OXID versions before 6.2 or
2. OXID is not an enterprise edition

This closes MAKAIRA-1852