### PR TITLE
PHP8 Workaround for category tree

### DIFF
--- a/src/oxid/core/makaira_connect_request_handler.php
+++ b/src/oxid/core/makaira_connect_request_handler.php
@@ -304,15 +304,15 @@ class makaira_connect_request_handler
     {
         if ($cats && $selectedCats) {
             foreach ($cats as $cat) {
-                $key = array_search($cat->key, (array) $selectedCats);
+                $key = array_search($cat['key'], (array) $selectedCats);
                 if (false !== $key) {
-                    $cat->selected        = true;
-                    $selectedCats[ $key ] = $cat->title;
+                    $cat['selected']        = true;
+                    $selectedCats[ $key ] = $cat['title'];
                 } else {
-                    $cat->selected = false;
+                    $cat['selected'] = false;
                 }
-                if ($cat->subtree) {
-                    $this->mapCategoryTitle($cat->subtree, $selectedCats);
+                if ($cat['subtree']) {
+                    $this->mapCategoryTitle($cat['subtree'], $selectedCats);
                 }
             }
         }
@@ -376,10 +376,6 @@ class makaira_connect_request_handler
 
                     break;
                 case 'categorytree':
-                    // TODO: find better way to convert multi-array to multi-stdobject
-                    $aggregations[$aggregation->key]->values =
-                        json_decode(json_encode($aggregations[$aggregation->key]->values));
-
                     $aggregations[$aggregation->key]->selectedValues =
                         isset($query->aggregations[$aggregation->key]) ?
                             $unmodifiedQuery->aggregations[$aggregation->key] : [];

--- a/views/tpl/filter/category/tree.tpl
+++ b/views/tpl/filter/category/tree.tpl
@@ -12,23 +12,23 @@
                 </button>
             </li>
         [{/if}]
-        <li class="makaira-filter__item[{if $item->selected}] makaira-filter__item--active[{/if}]">
-            [{if $item->count}]
+        <li class="makaira-filter__item[{if $item.selected}] makaira-filter__item--active[{/if}]">
+            [{if $item.count}]
                 <label class="makaira-filter__label">
                     <input
                             type="checkbox"
                             name="[{$oViewConf->getFilterParamName()}][[{$aggregation->key}]][]"
                             class="makaira-input makaira-input--checkbox"
-                            value="[{$item->key}]"
-                            [{if $item->selected}]checked="checked"[{/if}]
+                            value="[{$item.key}]"
+                            [{if $item.selected}]checked="checked"[{/if}]
                     />
-                    [{$item->title}] [{if $blShowDocCount && $item->count}]([{$item->count}])[{/if}]
+                    [{$item.title}] [{if $blShowDocCount && $item.count}]([{$item.count}])[{/if}]
                 </label>
             [{else}]
-                <span>[{$item->title}]</span>
+                <span>[{$item.title}]</span>
             [{/if}]
-            [{if $item->subtree}]
-                [{fun name="makaira_filter_tree" items=$item->subtree isInnerTree=true loopName="innerItems"}]
+            [{if $item.subtree}]
+                [{fun name="makaira_filter_tree" items=$item.subtree isInnerTree=true loopName="innerItems"}]
             [{/if}]
         </li>
 


### PR DESCRIPTION
In php8 count() can't be used in objects that don't implement Countable, therefore the smarty foreach loop will not work with $aggregation->values being an object. I had to remove the object conversion part as it also affected the "subtree"