### PR TITLE
Respect current port when redirecting search form POST to GET

### DIFF
--- a/src/oxid/core/makaira_connect_oxviewconfig.php
+++ b/src/oxid/core/makaira_connect_oxviewconfig.php
@@ -323,7 +323,16 @@ class makaira_connect_oxviewconfig extends makaira_connect_oxviewconfig_parent
             $query = '?' . $query;
         }
 
-        $this->generatedFilterUrl[ $baseUrl ] = "{$parsedUrl['scheme']}://{$parsedUrl['host']}{$path}{$query}";
+        $isCustomPort = true;
+        if ('http' === $parsedUrl['scheme'] && 80 === $parsedUrl['port']) {
+            $isCustomPort = false;
+        }
+        if ('https' === $parsedUrl['scheme'] && 443 === $parsedUrl['port']) {
+            $isCustomPort = false;
+        }
+        $port = $isCustomPort ? ":{$parsedUrl['port']}" : '';
+
+        $this->generatedFilterUrl[ $baseUrl ] = "{$parsedUrl['scheme']}://{$parsedUrl['host']}{$port}{$path}{$query}";
 
         return $this->generatedFilterUrl[ $baseUrl ];
     }


### PR DESCRIPTION
When running Oxid on a non-default webserver port (such as 8000), the search form will redirect to the default port (either 80 or 443), instead of respecting the current port.