### PR TITLE
Classes that are not dependent on the OXID autoloader.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,13 @@
     "phpcompatibility/php-compatibility": "^9.3"
   },
   "autoload": {
-    "classmap": ["src/"],
+    "classmap": [
+      "src/oxid/core/makaira_connect_events.php",
+      "src/oxid/core/makaira_connect_helper.php",
+      "src/oxid/core/makaira_connect_request_handler.php",
+      "src/oxid/core/makaira_cookie_utils.php",
+      "src/oxid/core/makaira_tracking_data_generator.php"
+    ],
     "psr-4": {
         "Makaira\\Connect\\": ["src/Makaira/Connect"]
     }


### PR DESCRIPTION
Packt man diese Klasse \OxidEsales\Eshop\Application\Model\Article::class in die Session.
Gibt es einen Fehler beim zweiten Aufruf. Wenn die Session wiederhergestellt wird.
Da greift der Composer Autloader schneller als der OXID autoloader und dann kracht es.
Weil die von den unterschiedlichen Ordner geladen werden. 

- einmal von `/vendor/../makaira_connect_oxarticle.php`
- und einmal von `/source/module/makaira/../makaira_connect_oxarticle.php`

Hier habe ich ein PHP Script geschrieben um den Fehler nach zu produzieren.
https://gist.github.com/tmloberon/79d52033c3be18094475146bcb2a0c74

Man muss http://oxid-esale.local/autoloaderBug.php zwei mal aufrufen. Beim zweiten mal tritt der Fehler auf.

```
Fatal error: Cannot declare class makaira_connect_oxarticle, because the name is already in use in
/var/www/loberon/source/modules/makaira/connect/src/oxid/application/models/makaira_connect_oxarticle.php on line 0
```
