### PR TITLE
To modify the query and response to Makaira API, with DI.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -112,6 +112,7 @@ services:
       $oxLang: '@makaira.connect.oxid.language'
       $operationalIntelligence: '@Makaira\Connect\Utils\OperationalIntelligence'
       $searchHandler: '@Makaira\Connect\SearchHandler'
+      $dispatcher: '@Symfony\Component\EventDispatcher\EventDispatcherInterface'
 
   # makaira.connect.searchhandler
   Makaira\Connect\SearchHandler:

--- a/src/Makaira/Connect/Core/Autosuggester.php
+++ b/src/Makaira/Connect/Core/Autosuggester.php
@@ -394,9 +394,11 @@ class Autosuggester
      */
     public function afterSearchRequest(&$result)
     {
+        $event = new AutoSuggesterResponseEvent($result);
         $this->dispatcher->dispatch(
             AutoSuggesterResponseEvent::NAME,
-            new AutoSuggesterResponseEvent($result)
+            $event
         );
+        $result = (array)$event->getResult();
     }
 }

--- a/src/Makaira/Connect/Core/Autosuggester.php
+++ b/src/Makaira/Connect/Core/Autosuggester.php
@@ -10,11 +10,14 @@
 
 namespace Makaira\Connect\Core;
 
+use Makaira\Connect\Event\ModifierQueryRequestEvent;
+use Makaira\Connect\Event\AutoSuggesterResponseEvent;
 use oxLang as Language;
 use Makaira\Connect\SearchHandler;
 use Makaira\Connect\Utils\OperationalIntelligence;
 use Makaira\Constraints;
 use Makaira\Query;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class makaira_connect_autosuggester
@@ -36,14 +39,21 @@ class Autosuggester
      */
     private $searchHandler;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
     public function __construct(
         Language $oxLang,
         OperationalIntelligence $operationalIntelligence,
-        SearchHandler $searchHandler
+        SearchHandler $searchHandler,
+        EventDispatcherInterface $dispatcher
     ) {
         $this->oxLang = $oxLang;
         $this->operationalIntelligence = $operationalIntelligence;
         $this->searchHandler = $searchHandler;
+        $this->dispatcher = $dispatcher;
     }
 
     /**
@@ -373,6 +383,10 @@ class Autosuggester
      */
     public function modifyRequest(Query &$query)
     {
+        $this->dispatcher->dispatch(
+            ModifierQueryRequestEvent::NAME_AUTOSUGGESTER,
+            new ModifierQueryRequestEvent($query)
+        );
     }
 
     /**
@@ -380,5 +394,9 @@ class Autosuggester
      */
     public function afterSearchRequest(&$result)
     {
+        $this->dispatcher->dispatch(
+            AutoSuggesterResponseEvent::NAME,
+            new AutoSuggesterResponseEvent($result)
+        );
     }
 }

--- a/src/Makaira/Connect/Event/AutoSuggesterResponseEvent.php
+++ b/src/Makaira/Connect/Event/AutoSuggesterResponseEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Makaira\Connect\Event;
+
+use Makaira\Result;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * After receiving the Auggester, you can still adjust it for the display.
+ */
+class AutoSuggesterResponseEvent extends Event
+{
+    public const NAME = 'makaira.response.autosuggester';
+
+    private $result;
+
+    public function __construct(Result &$result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @return Result
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+}

--- a/src/Makaira/Connect/Event/AutoSuggesterResponseEvent.php
+++ b/src/Makaira/Connect/Event/AutoSuggesterResponseEvent.php
@@ -16,13 +16,13 @@ class AutoSuggesterResponseEvent extends Event
 
     private $result;
 
-    public function __construct(Result &$result)
+    public function __construct($result)
     {
-        $this->result = $result;
+        $this->result = new \ArrayObject($result);
     }
 
     /**
-     * @return Result
+     * @return \ArrayObject
      */
     public function getResult()
     {

--- a/src/Makaira/Connect/Event/ModifierQueryRequestEvent.php
+++ b/src/Makaira/Connect/Event/ModifierQueryRequestEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Makaira\Connect\Event;
+
+use Makaira\Query;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Possibility to change the query before sending it to Makaira.
+ */
+class ModifierQueryRequestEvent extends Event
+{
+    public const NAME_SEARCH = 'makaira.request.modifier.query.search';
+
+    public const NAME_AUTOSUGGESTER = 'makaira.request.modifier.query.autosuggester';
+
+    private $query;
+
+    public function __construct(Query $query)
+    {
+        $this->query = $query;
+    }
+
+    /**
+     * @return Query
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+}

--- a/src/Makaira/Connect/Event/SearchResponseEvent.php
+++ b/src/Makaira/Connect/Event/SearchResponseEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Makaira\Connect\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * After receiving the $productIds you can still adjust them
+ */
+class SearchResponseEvent extends Event
+{
+    public const NAME = 'makaira.response.search';
+
+    /**
+     * @var array
+     */
+    private $productIds;
+
+    public function __construct(array $productIds)
+    {
+        $this->productIds = new \ArrayObject($productIds);
+    }
+
+    /**
+     * @return array
+     */
+    public function getProductIds()
+    {
+        return $this->productIds;
+    }
+}

--- a/tests/Makaira/Connect/ApiEventTest.php
+++ b/tests/Makaira/Connect/ApiEventTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oxidprojects\DI\Tests\Makaira\Connect;
+
+use Makaira\Connect\Core\Autosuggester;
+use Makaira\Connect\Event\AutoSuggesterResponseEvent;
+use Makaira\Connect\Event\ModifierQueryRequestEvent;
+use Makaira\Connect\Event\SearchResponseEvent;
+use Makaira\Connect\IntegrationTest;
+use Makaira\Connect\Utils\OperationalIntelligence;
+use Makaira\Query;
+use Makaira\Result;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ApiEventTest extends IntegrationTest
+{
+    public function testQueryAutosuggesterEvent()
+    {
+        //Arrange
+        $container = $this->getContainer();
+        $event = $container->get(EventDispatcherInterface::class);
+        $autosuggester = $container->get(Autosuggester::class);
+        $query = new Query(['searchPhrase' => 'Tisch']);
+
+        //Act
+        $event->addListener(ModifierQueryRequestEvent::NAME_AUTOSUGGESTER, [$this, 'listenerModifierQueryRequest']);
+
+        $autosuggester->modifyRequest($query);
+        $accept = $query->searchPhrase;
+
+        //Assert
+        $this->assertEquals('Bett', $accept);
+    }
+
+    public function testQuerySearchEvent()
+    {
+        //Arrange
+        $container = $this->getContainer();
+        $event = $container->get(EventDispatcherInterface::class);
+        $makaira_connect_request_handler = new \makaira_connect_request_handler();
+        $reflectionClass = new \ReflectionClass(\makaira_connect_request_handler::class);
+        $methodModifyRequest = $reflectionClass->getMethod('modifyRequest');
+        $methodModifyRequest->setAccessible(true);
+
+        $query = new Query(['searchPhrase' => 'Tische']);
+
+        //Act
+        $event->addListener(ModifierQueryRequestEvent::NAME_SEARCH, [$this, 'listenerModifierQueryRequest']);
+
+        $methodModifyRequest->invoke($makaira_connect_request_handler, $query);
+        $accept = $query->searchPhrase;
+
+        //Assert
+        $this->assertEquals('Bett', $accept);
+    }
+
+    public function testResponseSearchEvent()
+    {
+        //Arrange
+        $container = $this->getContainer();
+        $event = $container->get(EventDispatcherInterface::class);
+        $makaira_connect_request_handler = new \makaira_connect_request_handler();
+
+        $productIds = ['1234'];
+        $expect = ['1234', 'Extra ID'];
+
+        //Act
+        $event->addListener(SearchResponseEvent::NAME, [$this, 'listenerSearchResponse']);
+        $makaira_connect_request_handler->afterSearchRequest($productIds);
+
+        //Assert
+        $this->assertEquals($expect, $productIds);
+    }
+
+    public function testResponseAutoSuggesterResponseEvent()
+    {
+        //Arrange
+        $container = $this->getContainer();
+        $event = $container->get(EventDispatcherInterface::class);
+        $autosuggester = $container->get(Autosuggester::class);
+
+        $result = new Result(['count' => 33]);
+
+        //Act
+        $event->addListener(AutoSuggesterResponseEvent::NAME, [$this, 'listenerResponseAutoSuggester']);
+        $autosuggester->afterSearchRequest($result);
+
+        //Assert
+        $this->assertEquals(66, $result->count);
+    }
+
+    public function listenerResponseAutoSuggester(AutoSuggesterResponseEvent $event) {
+        $event->getResult()->count = 66;
+    }
+
+    public function listenerModifierQueryRequest(ModifierQueryRequestEvent $event) {
+        $event->getQuery()->searchPhrase = 'Bett';
+    }
+
+    public function listenerSearchResponse(SearchResponseEvent $event)
+    {
+        $productIds = $event->getProductIds();
+        $productIds[] = 'Extra ID';
+    }
+
+    protected function setUp(): void
+    {
+        $container = $this->getContainer();
+        $event = $container->get(EventDispatcherInterface::class);
+        $event->removeListener(ModifierQueryRequestEvent::NAME_AUTOSUGGESTER, [$this, 'listenerModifierQueryRequest']);
+        $event->removeListener(ModifierQueryRequestEvent::NAME_SEARCH, [$this, 'listenerModifierQueryRequest']);
+        $event->removeListener(SearchResponseEvent::NAME, [$this, 'listenerSearchResponse']);
+        $event->removeListener(AutoSuggesterResponseEvent::NAME, [$this, 'listenerResponseAutoSuggester']);
+    }
+}

--- a/tests/Makaira/Connect/ApiEventTest.php
+++ b/tests/Makaira/Connect/ApiEventTest.php
@@ -81,18 +81,20 @@ class ApiEventTest extends IntegrationTest
         $event = $container->get(EventDispatcherInterface::class);
         $autosuggester = $container->get(Autosuggester::class);
 
-        $result = new Result(['count' => 33]);
+        $result = ['count' => 33];
 
         //Act
         $event->addListener(AutoSuggesterResponseEvent::NAME, [$this, 'listenerResponseAutoSuggester']);
         $autosuggester->afterSearchRequest($result);
 
         //Assert
-        $this->assertEquals(66, $result->count);
+        $this->assertEquals(66, $result['count']);
     }
 
     public function listenerResponseAutoSuggester(AutoSuggesterResponseEvent $event) {
-        $event->getResult()->count = 66;
+        $result = $event->getResult();
+        $this->assertInstanceOf(\ArrayObject::class, $result);
+        $result['count'] = 66;
     }
 
     public function listenerModifierQueryRequest(ModifierQueryRequestEvent $event) {

--- a/tests/Makaira/Connect/OxidMocks/oxRegistry.php
+++ b/tests/Makaira/Connect/OxidMocks/oxRegistry.php
@@ -77,6 +77,8 @@ class oxRegistry
             case 'oxseoencodercategory':
             case 'oxseoencodermanufacturer':
                 return new oxSeoEncoder();
+            case 'makaira_cookie_utils':
+                return new makaira_cookie_utils();
         }
 
         return null;


### PR DESCRIPTION
Some events were added to process the request. With the Symfony DI.
So you don't have to activate another OXID module.

There are the Event:
- `makaira.response.autosuggester` (`\Makaira\Connect\Event\AutoSuggesterResponseEvent::NAME`)
- `makaira.response.search` (`\Makaira\Connect\Event\SearchResponseEvent::NAME`)
- `makaira.request.modifier.query.search` (`\Makaira\Connect\Event\ModifierQueryRequestEvent::NAME_SEARCH`)
- `makaira.request.modifier.query.autosuggester` (`\Makaira\Connect\Event\ModifierQueryRequestEvent::NAME_AUTOSUGGESTER`)

With UnitTests
I have not tested it on version 3x, because the dispatch function changes and I have not installed a new OXID.